### PR TITLE
Ticket/55 publish ncids react

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@nciocpl:registry=https://npm.pkg.github.com

--- a/README.md
+++ b/README.md
@@ -28,3 +28,9 @@ NCIDS is built as a monorepo, utilizing *yarn* and *yarn workspaces* for depende
 If there’s a dependency that all packages use but that you want to remove, Lerna has the _exec_ command that runs an arbitrary command in each package. With this knowledge, we can use _exec_ to remove a dependency on all packages.
 
  `lerna exec -- yarn remove dep-name`
+
+## Publishing
+
+Publishing of the ncids-css and ncids-react packages is done by running the command: 
+`lerna publish`
+Running the command will assist in versioning, kick off package tests, build the packages and finally publish to github.

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nci-design-system",
-  "version": "0.1.0-alpha.15",
+  "version": "0.1.0-alpha.11",
   "description": "NCI Design System",
   "author": "NCIOCPL",
   "private": true,
@@ -21,8 +21,8 @@
   "dependencies": {
     "@mdx-js/mdx": "^1.6.22",
     "@mdx-js/react": "^1.6.22",
-    "@nciocpl/ncids-css": "^0.1.0-alpha.15",
-    "@nciocpl/ncids-react": "^0.1.0-alpha.15",
+    "@nciocpl/ncids-css": "^0.1.0-alpha.11",
+    "@nciocpl/ncids-react": "^0.1.0-alpha.11",
     "copy-to-clipboard": "^3.3.1",
     "gatsby": "^3.1.1",
     "gatsby-plugin-catch-links": "^3.1.0",

--- a/lerna.json
+++ b/lerna.json
@@ -1,9 +1,23 @@
 {
-  "packages": [
-    "packages/*",
-    "docs/*"
-  ],
-  "version": "independent",
-  "npmClient": "yarn",
-  "useWorkspaces": true
+	"command": {
+		"publish": {
+			"registry": "https://npm.pkg.github.com",
+			"access": "public"
+		}
+	},
+	"packages": [
+		"packages/*",
+		"docs"
+	],
+	"publish": {
+		"allowBranch": [
+			"develop",
+			"ticket/*",
+			"hotfix/*",
+			"main"
+		]
+	},
+	"npmClient": "yarn",
+	"useWorkspaces": true,
+	"version": "0.1.0-alpha.11"
 }

--- a/packages/ncids-css/.npmignore
+++ b/packages/ncids-css/.npmignore
@@ -1,0 +1,7 @@
+src
+config
+unit
+node_modules
+.prettierrc
+.stylelintrc.json
+gulpfile.js

--- a/packages/ncids-css/LICENSE.md
+++ b/packages/ncids-css/LICENSE.md
@@ -1,0 +1,61 @@
+## A few parts of this project are not in the public domain
+
+### Files licensed under the SIL Open Font License, Version 1.1
+
+The Source Sans Pro font files in `src/fonts/source-sans-pro` are a [customized subset](https://github.com/miguelsousa/source-sans-pro-subset) of [Source Sans Pro](https://github.com/adobe-fonts/source-sans-pro) owned by Adobe Systems Incorporated, licensed under the [SIL Open Font License, Version 1.1](https://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=OFL_web), and copyright 2010, 2012, 2014 [Adobe Systems Incorporated], with Reserved Font Name 'Source'. All Rights Reserved. Source is a trademark of Adobe Systems Incorporated in the United States or other countries.
+
+The Merriweather font files in `src/fonts/merriweather` are the version 2.001 files from [GitHub](https://github.com/EbenSorkin/Merriweather/releases/tag/v2.001) subsetted into Latin and with additional formats generated with [Transfonter](https://transfonter.org/), licensed under the [SIL Open Font License, Version 1.1](https://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=OFL_web), and copyright [Sorkin Type Co](www.sorkintype.com) with Reserved Font Name 'Merriweather'.
+
+The Public Sans font files in `src/fonts/public-sans` are licensed under the [SIL Open Font License, Version 1.1](https://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=OFL_web). Public Sans is a modification of Libre Franklin, copyright [Impallari Type](www.impallari.com).
+
+The files in `src/img` are from [Font Awesome](http://fontawesome.io/) by Dave Gandy under the [SIL Open Font License, Version 1.1](https://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=OFL_web).
+
+### Files licensed under the Apache 2.0 License
+
+The Roboto Mono font files in `src/fonts/roboto-mono` are licensed under the [Apache License Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt).
+
+The Google Material icons in `src/img/usa-icons` and `src/img/usa-icons-unused` are licensed under the [Apache License Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt).
+
+### Files licensed under the MIT license
+
+The files in `src/stylesheets/lib` are from:
+
+- [Normalize.css](https://github.com/necolas/normalize.css), copyright Nicolas Gallagher and Jonathan Neal, under the [MIT license](https://github.com/necolas/normalize.css/blob/master/LICENSE.md).
+
+#### Full license text for the MIT licensed files:
+
+```
+The MIT License (MIT)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+```
+
+## The rest of this project is in the worldwide public domain
+
+As a work of the United States government, this project is in the public domain within the United States.
+
+Additionally, we waive copyright and related rights in the work worldwide through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
+
+### CC0 1.0 Universal Summary
+
+This is a human-readable summary of the [Legal Code (read the full text)](https://creativecommons.org/publicdomain/zero/1.0/legalcode).
+
+#### No Copyright
+
+The person who associated a work with this deed has dedicated the work to the public domain by waiving all of his or her rights to the work worldwide under copyright law, including all related and neighboring rights, to the extent allowed by law.
+
+You can copy, modify, distribute and perform the work, even for commercial purposes, all without asking permission.
+
+#### Other Information
+
+In no way are the patent or trademark rights of any person affected by CC0, nor are the rights that other persons may have in the work or in how the work is used, such as publicity or privacy rights.
+
+Unless expressly stated otherwise, the person who associated a work with this deed makes no warranties about the work, and disclaims liability for all uses of the work, to the fullest extent permitted by applicable law. When using or citing the work, you should not imply endorsement by the author or the affirmer.
+
+### Contributions to this project
+
+As stated in [CONTRIBUTING](CONTRIBUTING.md), all contributions to this project will be released under the CC0 dedication. By submitting a pull request, you are agreeing to comply with this waiver of copyright interest.

--- a/packages/ncids-css/README.md
+++ b/packages/ncids-css/README.md
@@ -1,6 +1,19 @@
 # ncids-css
+## Getting Started
+In order to download the ncids-css package, you will have to set up the @nciocpl organizational scope in npm to see the package.  Create a .npmrc file in the root of your project containing the following:
 
-## SASS/CSS package for the NCIDS
+```
+@nciocpl:registry=https://npm.pkg.github.com
+```
+
+Install ncids-react via the command line
+
+```
+$ npm install @nciocpl/ncids-css
+```
+
+#
+## Documentation
 
 This package will build the NCIDS css from the included scss files & the uswds design system scss files. This process adds in our special token pallets, and other overrides into the existing system to fit the NCI brand design.
 

--- a/packages/ncids-css/package.json
+++ b/packages/ncids-css/package.json
@@ -1,11 +1,20 @@
 {
 	"name": "@nciocpl/ncids-css",
-	"version": "0.1.0-alpha.15",
+	"version": "0.1.0-alpha.11",
 	"description": "CSS library for the National Cancer Institue Desgn System(NCIDS)",
+	"repository": {
+		"type": "git",
+		"url": "ssh://git@github.com/nciocpl/ncids.git",
+		"directory": "packages/ncids-css"
+	},
+	"publishConfig": {
+		"registry": "https://npm.pkg.github.com/",
+		"access": "public"
+	},
 	"main": "index.scss",
 	"scripts": {
-		"build": "gulp build",
 		"clean:build": "rimraf ./dist",
+		"build": "yarn run clean:build && gulp build",
 		"test:sass": "mocha unit/sass-spec.js",
 		"watch": "NODE_ENV=development nswatch",
 		"lint": "stylelint scss/**/*.scss",

--- a/packages/ncids-react/LICENSE.md
+++ b/packages/ncids-react/LICENSE.md
@@ -1,0 +1,61 @@
+## A few parts of this project are not in the public domain
+
+### Files licensed under the SIL Open Font License, Version 1.1
+
+The Source Sans Pro font files in `src/fonts/source-sans-pro` are a [customized subset](https://github.com/miguelsousa/source-sans-pro-subset) of [Source Sans Pro](https://github.com/adobe-fonts/source-sans-pro) owned by Adobe Systems Incorporated, licensed under the [SIL Open Font License, Version 1.1](https://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=OFL_web), and copyright 2010, 2012, 2014 [Adobe Systems Incorporated], with Reserved Font Name 'Source'. All Rights Reserved. Source is a trademark of Adobe Systems Incorporated in the United States or other countries.
+
+The Merriweather font files in `src/fonts/merriweather` are the version 2.001 files from [GitHub](https://github.com/EbenSorkin/Merriweather/releases/tag/v2.001) subsetted into Latin and with additional formats generated with [Transfonter](https://transfonter.org/), licensed under the [SIL Open Font License, Version 1.1](https://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=OFL_web), and copyright [Sorkin Type Co](www.sorkintype.com) with Reserved Font Name 'Merriweather'.
+
+The Public Sans font files in `src/fonts/public-sans` are licensed under the [SIL Open Font License, Version 1.1](https://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=OFL_web). Public Sans is a modification of Libre Franklin, copyright [Impallari Type](www.impallari.com).
+
+The files in `src/img` are from [Font Awesome](http://fontawesome.io/) by Dave Gandy under the [SIL Open Font License, Version 1.1](https://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=OFL_web).
+
+### Files licensed under the Apache 2.0 License
+
+The Roboto Mono font files in `src/fonts/roboto-mono` are licensed under the [Apache License Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt).
+
+The Google Material icons in `src/img/usa-icons` and `src/img/usa-icons-unused` are licensed under the [Apache License Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt).
+
+### Files licensed under the MIT license
+
+The files in `src/stylesheets/lib` are from:
+
+- [Normalize.css](https://github.com/necolas/normalize.css), copyright Nicolas Gallagher and Jonathan Neal, under the [MIT license](https://github.com/necolas/normalize.css/blob/master/LICENSE.md).
+
+#### Full license text for the MIT licensed files:
+
+```
+The MIT License (MIT)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+```
+
+## The rest of this project is in the worldwide public domain
+
+As a work of the United States government, this project is in the public domain within the United States.
+
+Additionally, we waive copyright and related rights in the work worldwide through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
+
+### CC0 1.0 Universal Summary
+
+This is a human-readable summary of the [Legal Code (read the full text)](https://creativecommons.org/publicdomain/zero/1.0/legalcode).
+
+#### No Copyright
+
+The person who associated a work with this deed has dedicated the work to the public domain by waiving all of his or her rights to the work worldwide under copyright law, including all related and neighboring rights, to the extent allowed by law.
+
+You can copy, modify, distribute and perform the work, even for commercial purposes, all without asking permission.
+
+#### Other Information
+
+In no way are the patent or trademark rights of any person affected by CC0, nor are the rights that other persons may have in the work or in how the work is used, such as publicity or privacy rights.
+
+Unless expressly stated otherwise, the person who associated a work with this deed makes no warranties about the work, and disclaims liability for all uses of the work, to the fullest extent permitted by applicable law. When using or citing the work, you should not imply endorsement by the author or the affirmer.
+
+### Contributions to this project
+
+As stated in [CONTRIBUTING](CONTRIBUTING.md), all contributions to this project will be released under the CC0 dedication. By submitting a pull request, you are agreeing to comply with this waiver of copyright interest.

--- a/packages/ncids-react/README.md
+++ b/packages/ncids-react/README.md
@@ -1,0 +1,16 @@
+# NCIDS-React (@nciocpl/ncids-react)
+NCIDS-React serves as a React-based UI component library for the National Cancer Institute Design System(NCIDS).  
+
+## Getting Started
+In order to download the ncids-react package, you will have to set up the @nciocpl organizational scope in npm to see the package.  Create a .npmrc file in the root of your project containing the following:
+
+```
+@nciocpl:registry=https://npm.pkg.github.com
+```
+
+Install ncids-react via the command line
+
+```
+$ npm install @nciocpl/ncids-react
+```
+

--- a/packages/ncids-react/package.json
+++ b/packages/ncids-react/package.json
@@ -1,10 +1,19 @@
 {
   "name": "@nciocpl/ncids-react",
-  "version": "0.1.0-alpha.15",
+  "version": "0.1.0-alpha.11",
   "description": "React component library for the National Cancer Institue Design System(NCIDS)",
   "main": "./lib/index.js",
   "author": "NCIOCPL",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "ssh://git@github.com/nciocpl/ncids.git",
+    "directory": "packages/ncids-react"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
+  },
   "scripts": {
     "chores": "yarn run lint && yarn run test",
     "prebuild": "yarn run chores",

--- a/packages/ncids-react/src/components/button/__tests__/button.test.js
+++ b/packages/ncids-react/src/components/button/__tests__/button.test.js
@@ -25,6 +25,26 @@ describe("Button component", () => {
 		expect(getByText(/submit/i)).toHaveAttribute("type", "submit");
 	});
 
+	it("renders a 'secondary' variant", () => {
+		const { getByText } = render(<Button label="test" variant="secondary" />);
+		expect(getByText(/test/i)).toHaveClass("usa-button--secondary");
+	});
+
+	it("renders a 'outline' variant", () => {
+		const { getByText } = render(<Button label="test" variant="outline" />);
+		expect(getByText(/test/i)).toHaveClass("usa-button--outline");
+	});
+
+	it("renders a 'big' variant", () => {
+		const { getByText } = render(<Button label="test" variant="big" />);
+		expect(getByText(/test/i)).toHaveClass("usa-button--big");
+	});
+
+	it("renders a 'unstyled' variant", () => {
+		const { getByText } = render(<Button label="test" variant="unstyled" />);
+		expect(getByText(/test/i)).toHaveClass("usa-button--unstyled");
+	});
+
 	it("renders a disabled button when passed disabled", () => {
 		const { getByText } = render(<Button disabled label="Disabled Button" />);
 		expect(getByText(/disabled button/i)).toBeDisabled();

--- a/packages/ncids-react/src/components/button/button.jsx
+++ b/packages/ncids-react/src/components/button/button.jsx
@@ -2,15 +2,30 @@ import React from "react";
 import PropTypes from "prop-types";
 
 const Button = ({
-	label,
 	classes = "",
-	type = "button",
 	disabled = false,
+	label,
 	onClick,
+	type = "button",
+	variant = "",
 	...otherProps
 }) => {
 	// gather up classes display classes
 	let displayClasses = ["usa-button"];
+	switch (variant) {
+		case "secondary":
+			displayClasses.push("usa-button--secondary");
+			break;
+		case "outline":
+			displayClasses.push("usa-button--outline");
+			break;
+		case "big":
+			displayClasses.push("usa-button--big");
+			break;
+		case "unstyled":
+			displayClasses.push("usa-button--unstyled");
+			break;
+	}
 	// add classes from props
 	displayClasses.push(classes);
 
@@ -28,12 +43,13 @@ const Button = ({
 };
 
 Button.propTypes = {
-	label: PropTypes.node.isRequired,
 	classes: PropTypes.string,
-	onClick: PropTypes.func,
 	disabled: PropTypes.bool,
-	type: PropTypes.oneOf(["button", "reset", "submit"]),
+	label: PropTypes.node.isRequired,
+	onClick: PropTypes.func,
 	otherProps: PropTypes.array,
+	type: PropTypes.oneOf(["button", "reset", "submit"]),
+	variant: PropTypes.oneOf(["secondary", "outline", "big", "unstyled"]),
 };
 
 export default Button;


### PR DESCRIPTION
Closes #55 .

This work verifies that packages are published for @nciocpl/ncids-react and @nciocpl/ncids-css.  Instructions for downloading have been added to the Getting Started section of their respective READMEs.

- versions for within NCIDS will NOT be handled independently, meaning that the versions for published packages will match.
- placeholder LICENSE.md were added to each of the packages, these are REQUIRED
