### PR TITLE
Update NCIDS to use USWDS v2.12.0

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -39,8 +39,7 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-helmet": "^6.1.0",
-    "sass": "^1.32.8",
-    "uswds": "^2.11.1"
+    "sass": "^1.32.8"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.11.9",

--- a/packages/ncids-css/package.json
+++ b/packages/ncids-css/package.json
@@ -23,7 +23,7 @@
 		"object-assign": "^4.1.1",
 		"receptor": "^1.0.0",
 		"resolve-id-refs": "^0.1.0",
-		"uswds": "^2.10.1"
+		"uswds": "^2.12.0"
 	},
 	"devDependencies": {
 		"@babel/preset-env": "^7.12.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22752,30 +22752,14 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
-uswds@^2.10.1:
-  version "2.10.3"
-  resolved "https://registry.yarnpkg.com/uswds/-/uswds-2.10.3.tgz#16d34cee81897762d6d69d3ac83aa55129826fa6"
-  integrity sha512-krNRzx1jRzOJpuH/qtmQhd5zxnXTaDVqrPNYT99sJbxzWUqjb1zZHh3jFNo+xKDpNuiO0XMPwZwlaSp2YdZ3Ag==
+uswds@^2.12.0:
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/uswds/-/uswds-2.12.0.tgz#6430ca5dc0cda01a11f37519fb8f4cd3fe88944f"
+  integrity sha512-zunOnGXVOye8CSTjzakHBTdhH+Swi6uJLD5xOcI6xmlZFgNzk5qpLdcsxrjtknELBqRUccMRAp4MIlds9QQUMw==
   dependencies:
     classlist-polyfill "^1.0.3"
     del "^6.0.0"
     domready "^1.0.8"
-    elem-dataset "^2.0.0"
-    lodash.debounce "^4.0.7"
-    object-assign "^4.1.1"
-    receptor "^1.0.0"
-    resolve-id-refs "^0.1.0"
-
-uswds@^2.11.1:
-  version "2.11.1"
-  resolved "https://registry.yarnpkg.com/uswds/-/uswds-2.11.1.tgz#3061ca8d958d6cbcd1f08e1d760e2028c3d025df"
-  integrity sha512-yhLTik8AuiLdp+e7/v84unn1PF3f+qtYjcdsFRjy8+7TI2mTa4wk8/5oDaMJnk1LMA3tSQNkmxGetmOS1q4zXA==
-  dependencies:
-    classlist-polyfill "^1.0.3"
-    del "^6.0.0"
-    domready "^1.0.8"
-    elem-dataset "^2.0.0"
-    lodash.debounce "^4.0.7"
     object-assign "^4.1.1"
     receptor "^1.0.0"
     resolve-id-refs "^0.1.0"


### PR DESCRIPTION
Closes (#188 ) Update NCIDS to use USWDS v2.12.0