### PR TITLE
(#213) Break up components/_all

### DIFF
--- a/docs/src/index.scss
+++ b/docs/src/index.scss
@@ -1,7 +1,23 @@
 // $theme-image-path: '/uswds/images' !default;
 // $theme-font-path: '/uswds/fonts' !default;
 
-@import '@nciocpl/ncids-css/scss/ncids.scss';
+//@import '@nciocpl/ncids-css/scss/ncids.scss';
+
+// only bring in the partials we need, doing something similar to ncids.scss
+// normalize
+@import '@nciocpl/ncids-css/scss/base/normalize';
+
+// Required - functions, mixins
+@import '@nciocpl/ncids-css/scss/base/required';
+
+// Global - settings
+@import '@nciocpl/ncids-css/scss/base/global';
+
+// Components
+@import './scss/components';
+
+// Utilities
+@import '@nciocpl/ncids-css/scss/base/utilities';
 
 @import './scss/Code.scss';
 @import './scss/CopyToClipboard.scss';

--- a/docs/src/scss/_components.scss
+++ b/docs/src/scss/_components.scss
@@ -1,0 +1,57 @@
+// index file for NCIDS components
+// replace specific component partials with ncids equivalent here
+
+// Base
+// -------------------------------------
+@import 'uswds/dist/scss/base/body';
+@import 'uswds/dist/scss/base/accessibility';
+
+// Elements
+// -------------------------------------
+@import 'uswds/dist/scss/elements/buttons';
+// @import 'uswds/dist/scss/elements/embed';
+// @import 'uswds/dist/scss/elements/figure';
+// @import 'uswds/dist/scss/elements/form-controls/all';
+@import 'uswds/dist/scss/elements/layout-grid';
+@import 'uswds/dist/scss/elements/table';
+@import 'uswds/dist/scss/elements/tags';
+@import 'uswds/dist/scss/elements/typography/content';
+@import 'uswds/dist/scss/elements/typography/links';
+@import 'uswds/dist/scss/elements/typography/list';
+@import 'uswds/dist/scss/elements/typography/prose';
+
+// Components
+// -------------------------------------
+@import 'uswds/dist/scss/components/accordions';
+@import 'uswds/dist/scss/components/alerts';
+@import 'uswds/dist/scss/components/banner';
+// @import 'uswds/dist/scss/components/breadcrumb';
+// @import 'uswds/dist/scss/components/button-groups';
+// @import 'uswds/dist/scss/components/card';
+// @import 'uswds/dist/scss/components/checklist';
+// @import 'uswds/dist/scss/components/collection';
+@import 'uswds/dist/scss/components/footer';
+// @import 'uswds/dist/scss/components/forms';
+// @import 'uswds/dist/scss/components/graphic-list';
+@import 'uswds/dist/scss/components/header';
+// @import 'uswds/dist/scss/components/hero';
+// @import 'uswds/dist/scss/components/icon';
+// @import 'uswds/dist/scss/components/icon-list';
+// @import 'uswds/dist/scss/components/identifier';
+@import 'uswds/dist/scss/components/layout';
+// @import 'uswds/dist/scss/components/media-block';
+@import 'uswds/dist/scss/components/megamenu';
+// @import 'uswds/dist/scss/components/modal';
+@import 'uswds/dist/scss/components/nav-container';
+@import 'uswds/dist/scss/components/navbar';
+@import 'uswds/dist/scss/components/navigation';
+// @import 'uswds/dist/scss/components/pagination';
+// @import 'uswds/dist/scss/components/process-list';
+// @import 'uswds/dist/scss/components/search';
+// @import 'uswds/dist/scss/components/section';
+// @import 'uswds/dist/scss/components/sidenav';
+// @import 'uswds/dist/scss/components/site-alert';
+@import 'uswds/dist/scss/components/skipnav';
+// @import 'uswds/dist/scss/components/step-indicator';
+// @import 'uswds/dist/scss/components/summary-box';
+// @import 'uswds/dist/scss/components/tooltip';

--- a/packages/ncids-css/scss/base/_system-tokens.scss
+++ b/packages/ncids-css/scss/base/_system-tokens.scss
@@ -12,6 +12,9 @@ by NCIDS project teams.
 ----------------------------------------
 */
 
+// Turns off USWDS notifications/release notes logging
+$theme-show-notifications: false;
+
 /*
 ----------------------------------------
 Spacing grid multiplier

--- a/packages/ncids-css/scss/components/_all.scss
+++ b/packages/ncids-css/scss/components/_all.scss
@@ -1,4 +1,57 @@
 // index file for NCIDS components
+// replace specific component partials with ncids equivalent here
 
-// TEMPORARY - just use ALL of the USWDS elements and components
-@import 'uswds/dist/scss/packages/uswds-components';
+// Base
+// -------------------------------------
+@import 'uswds/dist/scss/base/body';
+@import 'uswds/dist/scss/base/accessibility';
+
+// Elements
+// -------------------------------------
+@import 'uswds/dist/scss/elements/buttons';
+@import 'uswds/dist/scss/elements/embed';
+@import 'uswds/dist/scss/elements/figure';
+@import 'uswds/dist/scss/elements/form-controls/all';
+@import 'uswds/dist/scss/elements/layout-grid';
+@import 'uswds/dist/scss/elements/table';
+@import 'uswds/dist/scss/elements/tags';
+@import 'uswds/dist/scss/elements/typography/content';
+@import 'uswds/dist/scss/elements/typography/links';
+@import 'uswds/dist/scss/elements/typography/list';
+@import 'uswds/dist/scss/elements/typography/prose';
+
+// Components
+// -------------------------------------
+@import 'uswds/dist/scss/components/accordions';
+@import 'uswds/dist/scss/components/alerts';
+@import 'uswds/dist/scss/components/banner';
+@import 'uswds/dist/scss/components/breadcrumb';
+@import 'uswds/dist/scss/components/button-groups';
+@import 'uswds/dist/scss/components/card';
+@import 'uswds/dist/scss/components/checklist';
+@import 'uswds/dist/scss/components/collection';
+@import 'uswds/dist/scss/components/footer';
+@import 'uswds/dist/scss/components/forms';
+@import 'uswds/dist/scss/components/graphic-list';
+@import 'uswds/dist/scss/components/header';
+@import 'uswds/dist/scss/components/hero';
+@import 'uswds/dist/scss/components/icon';
+@import 'uswds/dist/scss/components/icon-list';
+@import 'uswds/dist/scss/components/identifier';
+@import 'uswds/dist/scss/components/layout';
+@import 'uswds/dist/scss/components/media-block';
+@import 'uswds/dist/scss/components/megamenu';
+@import 'uswds/dist/scss/components/modal';
+@import 'uswds/dist/scss/components/nav-container';
+@import 'uswds/dist/scss/components/navbar';
+@import 'uswds/dist/scss/components/navigation';
+@import 'uswds/dist/scss/components/pagination';
+@import 'uswds/dist/scss/components/process-list';
+@import 'uswds/dist/scss/components/search';
+@import 'uswds/dist/scss/components/section';
+@import 'uswds/dist/scss/components/sidenav';
+@import 'uswds/dist/scss/components/site-alert';
+@import 'uswds/dist/scss/components/skipnav';
+@import 'uswds/dist/scss/components/step-indicator';
+@import 'uswds/dist/scss/components/summary-box';
+@import 'uswds/dist/scss/components/tooltip';


### PR DESCRIPTION
Closes #213 .

Breakout the components making up the list of components so that they can be overidden/replaced by ncids partials.

- update ncids components/_all to be a list of available local components and uswds components
- update usage of partials in documentation site to mimic how to use ncids partials to build scss for the site

https://designsystem-dev.cancer.gov/pr-214