### PR TITLE
(#400) Fix issue with focus tests

### DIFF
--- a/testing/ncids-css-testing/.backstop/engine-scripts/playwright/clickAndHoverHelper.js
+++ b/testing/ncids-css-testing/.backstop/engine-scripts/playwright/clickAndHoverHelper.js
@@ -28,6 +28,7 @@ module.exports = async (page, scenario) => {
 		for (const focusSelectorIndex of [].concat(focusSelector)) {
 			await page.waitForSelector(focusSelectorIndex);
 			await page.focus(focusSelectorIndex);
+			await page.mouse.move(10000,10000);
 		}
 	}
 


### PR DESCRIPTION
There was some sort of race condition in which it was possible for the "fake mouse" to be positioned over an element with focus, thus making that element focused and hovering. This was causing the skipnav stories to fail as focus and hover has two different colors. The fix is to position the mouse pointer to some location offscreen so this cannot happen. I am sure we will find the downside to this months from now.

Closes #400 