### PR TITLE
(#457) Bump Node and Use .nvmrc in workflow

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v2
         with:
-          node-version: '12'
+          node-version-file: '.nvmrc'
           cache: 'yarn'
           registry-url: https://npm.pkg.github.com
           scope: '@nciocpl'

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-12.*
+lts/gallium


### PR DESCRIPTION
Bumping Node to v14 which is the version people think we should be using, and thought we were using. 🤷

Closes #457