### PR TITLE
(#574) add loading spinners to header

### DIFF
--- a/packages/ncids-css/scss/components/nci-header/_nci-extended.scss
+++ b/packages/ncids-css/scss/components/nci-header/_nci-extended.scss
@@ -1,4 +1,6 @@
 // Dependencies
+@import '../../core/mixins/nci-place-icon';
+@import '../../utilities/nci-is-loading';
 @import 'uswds/dist/scss/elements/layout-grid';
 @import '../usa-button/all';
 

--- a/packages/ncids-css/scss/components/nci-header/internal/_megamenu.scss
+++ b/packages/ncids-css/scss/components/nci-header/internal/_megamenu.scss
@@ -9,6 +9,15 @@
 	z-index: z-index(400);
 	-webkit-font-smoothing: antialiased;
 
+	.nci-is-loading {
+		margin: units('card') auto;
+		&:after {
+			margin-top: units(-4);
+			position: relative;
+			background-color: color("white");
+		}
+	}
+
 	&.hidden,
 	&[aria-hidden="true"] {
 		display: none;

--- a/packages/ncids-css/scss/components/nci-header/internal/_navigation-mobile.scss
+++ b/packages/ncids-css/scss/components/nci-header/internal/_navigation-mobile.scss
@@ -61,6 +61,12 @@
     border-top: 1px solid color("gray-warm-10");
     margin-top: units(6);
   }
+
+	.nci-is-loading {
+		&:after {
+			margin-top: units(8);
+		}
+	}
 }
 
 .nci-header-mobilenav__overlay {

--- a/packages/ncids-css/scss/core/mixins/_nci-place-icon.scss
+++ b/packages/ncids-css/scss/core/mixins/_nci-place-icon.scss
@@ -1,0 +1,106 @@
+// Updated place icon
+//
+// Cannot use uswds add-background-svg mixin for masking and cannot use
+// place-icon when img is not located inside hardcoded usa-icon path
+// Removes IE fallback and usa-icon
+@mixin nci-add-color-icon($icon-object, $contrast-bg) {
+	$filename-base: map-get($icon-object, "name");
+	$svg-height: map-get($icon-object, "svg-height");
+	$svg-width: map-get($icon-object, "svg-width");
+	$aspect: divide($svg-width, $svg-height);
+	$height: if(
+			unitless(map-get($icon-object, "height")),
+			units(map-get($icon-object, "height")),
+			map-get($icon-object, "height")
+	);
+	$width: $height * $aspect;
+	$container-height: if(
+			map-has-key($icon-object, "container-height"),
+			units(map-get($icon-object, "container-height")),
+			null
+	);
+	$container-width: if(
+			map-has-key($icon-object, "container-width"),
+			units(map-get($icon-object, "container-width")),
+			null
+	);
+	$color: if(
+			map-has-key($icon-object, "color"),
+			map-get($icon-object, "color"),
+			"ink"
+	);
+	$color-variant: if(
+			map-has-key($icon-object, "color-variant"),
+			map-get($icon-object, "color-variant"),
+			"white"
+	);
+	$color-hover: if(
+			map-has-key($icon-object, "color-hover"),
+			map-get($icon-object, "color-hover"),
+			null
+	);
+	$rotate: if(
+			map-has-key($icon-object, "rotate"),
+			map-get($icon-object, "rotate"),
+			null
+	);
+	$path: if(
+			map-has-key($icon-object, "path"),
+			map-get($icon-object, "path"),
+			$theme-image-path
+	);
+
+	$mask-props:url("#{$path}/#{$filename-base}.svg") no-repeat center /
+    contain;
+
+	display: inline-block;
+	height: if($container-height, $container-height, $height);
+	width: if($container-width, $container-width, $width);
+	@if $rotate {
+		transform: rotate($rotate);
+	}
+
+	background: none;
+	background-color: if($color == currentColor, $color, color($color));
+	mask: $mask-props;
+	@if $color-hover {
+		&:hover {
+			background-color: color($color-hover);
+		}
+	}
+
+}
+
+// Places an icon before or after an element as an inline-block,
+// using the `:before` or `:after` pseudoelements.
+@mixin nci-place-icon(
+	$icon-object,
+	$direction,
+	$margin,
+	$vertical-align,
+	$contrast-bg
+) {
+	$color-hover: if(
+			map-has-key($icon-object, "color-hover"),
+			map-get($icon-object, "color-hover"),
+			null
+	);
+	&::#{$direction} {
+		@include nci-add-color-icon($icon-object, $contrast-bg);
+		content: "";
+		vertical-align: $vertical-align;
+
+		@if $direction == "after" {
+			margin-left: units($margin);
+		} @else {
+			margin-right: units($margin);
+		}
+	}
+
+	@if $color-hover {
+		&:hover::#{$direction} {
+			content: ""; // Added to address a weird display bug
+			background-color: color($color-hover);
+		}
+	}
+}

--- a/packages/ncids-css/scss/utilities/_nci-is-loading.scss
+++ b/packages/ncids-css/scss/utilities/_nci-is-loading.scss
@@ -1,0 +1,36 @@
+.nci-is-loading {
+	@include nci-place-icon(
+		(
+			'name': 'loader',
+			'svg-height': 40,
+			'svg-width': 40,
+			'height': 5,
+			'color': $theme-color-base-light,
+		),
+		'after',
+		'auto',
+		baseline,
+		'white'
+	);
+
+	&:after {
+		width: 100%;
+		position: absolute;
+		left: 0;
+		right: 0;
+	}
+
+	// 1s delay on fade in
+	opacity: 1;
+	transition: opacity 300ms ease 1s;
+
+	// Override transition on fade out
+	&.hidden {
+		opacity: 0;
+		transition: opacity 0s;
+
+		&:after {
+			display: none;
+		}
+	}
+}

--- a/packages/ncids-js/src/components/nci-header/__tests__/mega-menu/nci-header.mega-menu.test.ts
+++ b/packages/ncids-js/src/components/nci-header/__tests__/mega-menu/nci-header.mega-menu.test.ts
@@ -345,4 +345,29 @@ describe('NCI Extended Header - Mega Menu', () => {
 			});
 		});
 	});
+
+	it('set timeout state', async () => {
+		jest.useFakeTimers();
+
+		const container = headerWithDataMenuId();
+		document.body.append(container);
+
+		const element = document.getElementById('nci-header');
+		NCIExtendedHeaderWithMegaMenu.create(<HTMLElement>element, {
+			megaMenuSource: new MockMegaMenuAdaptor(false),
+			mobileMenuSource: new MockMobileMenuAdaptor(false),
+		});
+
+		const buttons = await screen.findAllByRole('button', { expanded: false });
+
+		fireEvent.click(buttons[0]);
+
+		jest.advanceTimersByTime(1000);
+
+		expect(
+			(<HTMLElement>element).querySelector('.nci-is-loading')
+		).toBeVisible();
+
+		jest.useRealTimers();
+	});
 });

--- a/packages/ncids-js/src/components/nci-header/utils/mobile-menu/mobile-menu.ts
+++ b/packages/ncids-js/src/components/nci-header/utils/mobile-menu/mobile-menu.ts
@@ -42,6 +42,11 @@ export class MobileMenu {
 	protected sectionParent: MobileMenuItem | null = null;
 	/** Document language code attribute */
 	protected langCode: 'en' | 'es';
+	/** Loading spinner */
+	protected loader: Element | HTMLElement = this.createDom('div', [
+		'nci-is-loading',
+		'hidden',
+	]);
 
 	/**
 	 * Array list of custom events that will be dispatched to the user.
@@ -161,6 +166,7 @@ export class MobileMenu {
 		this.mobileOverlay.remove();
 		this.mobileClose.remove();
 		this.mobileNav.remove();
+		this.loader.remove();
 	}
 
 	/**
@@ -180,6 +186,8 @@ export class MobileMenu {
 				]
 			)
 		);
+		this.mobileNav.ariaLive = 'polite';
+		this.mobileNav.ariaBusy = 'true';
 		this.mobileOverlay = <HTMLElement>(
 			this.createDom('div', ['nci-header-mobilenav__overlay'], [])
 		);
@@ -216,6 +224,7 @@ export class MobileMenu {
 		);
 
 		this.mobileNav.append(this.mobileClose);
+		this.mobileNav.append(this.loader);
 		this.element.append(this.mobileNav);
 		this.element.append(this.mobileOverlay);
 
@@ -230,6 +239,12 @@ export class MobileMenu {
 	 * @private
 	 */
 	private async handleOpenMenu(event: Event) {
+		// if we have a menu already - then remove it and redraw
+		const menuCheck = this.element.querySelector('.nci-header-mobilenav__list');
+		if (menuCheck) menuCheck.remove();
+		this.mobileNav.ariaBusy = 'true';
+		this.loader.classList.remove('hidden');
+
 		const target = event.currentTarget as HTMLElement;
 		const label = (target.textContent || '').trim();
 		await this.openMenu(label);
@@ -272,6 +287,8 @@ export class MobileMenu {
 		this.mobileClose.focus();
 		this.focusTrap.toggleTrap(true, this.mobileNav);
 
+		this.mobileNav.ariaBusy = 'false';
+
 		this.element.dispatchEvent(
 			this.customEvents['open']({
 				label: label,
@@ -311,6 +328,12 @@ export class MobileMenu {
 		action?: 'Back' | 'Child',
 		index?: number
 	): Promise<void> {
+		// if we have a menu already - then remove it and redraw
+		const menuCheck = this.element.querySelector('.nci-header-mobilenav__list');
+		if (menuCheck) menuCheck.remove();
+		this.mobileNav.ariaBusy = 'true';
+		this.loader.classList.remove('hidden');
+
 		const link = <HTMLElement>event.target;
 		const dataMenuID = link.getAttribute('data-menu-id');
 
@@ -346,10 +369,6 @@ export class MobileMenu {
 		const items = data.items;
 		this.sectionParent = data.parent;
 
-		// if we have a menu already - then remove it and redraw
-		const menuCheck = this.element.querySelector('.nci-header-mobilenav__list');
-		if (menuCheck) menuCheck.remove();
-
 		const menu = this.createDom('ul', ['nci-header-mobilenav__list']);
 
 		const childItems = items.map((item, index) => {
@@ -383,6 +402,8 @@ export class MobileMenu {
 			menu.append(...childItems);
 		}
 
+		this.mobileNav.ariaBusy = 'false';
+		this.loader.classList.add('hidden');
 		return <HTMLElement>menu;
 	}
 


### PR DESCRIPTION
Closes #574

To test, you may want to 
* Open up Chrome Dev Tools 
* Click Network tab 
* Check Disable caching 
* The dropdown that says "No throttling" switch to "Slow 3G" (don't forget to reset when done testing) 

Mega menu:
* Click a primary menu item

Mobile menu: 
* Open the menu 
* Load a new section menu

The spinners will show after a second delay to avoid flashing on faster speeds. 