### PR TITLE
(#983) Improve BS image gen workflow

### DIFF
--- a/.github/workflows/generate-bs-images.yml
+++ b/.github/workflows/generate-bs-images.yml
@@ -36,7 +36,8 @@ jobs:
           docker cp . "$CONTAINER_ID:/usr/local/apache2/htdocs"
       ## Now generate the reference images
       - name: Run image generation
-        run: yarn test:css:generate
+        working-directory: ./testing/ncids-css-testing
+        run: node_modules/.bin/backstop reference --config='backstop.config.js' --docker
         env:
           CI: true
           BACKSTOP_BASE_URL: http://localhost:8080/

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -155,7 +155,7 @@ jobs:
       ## Now test the css
       - name: Run css tests
         working-directory: ./testing/ncids-css-testing
-        run: yarn backstop:test
+        run: node_modules/.bin/backstop test --config='backstop.config.js' --docker
         env:
           CI: true
           BACKSTOP_BASE_URL: ${{ format('http://localhost:8080/{0}/storybook/', steps.set_vars.outputs.build_name) }}


### PR DESCRIPTION
- Removes yarn to stop silencing of errors
  ~Bumps backstopjs version to latest~

Closes #983


---

More descriptive errors yay: https://github.com/NCIOCPL/ncids/actions/runs/4917158047/jobs/8781877352#step:8:3255