### PR TITLE
(#926) Duplicate entries in CSS package.json

### DIFF
--- a/packages/ncids-css/package.json
+++ b/packages/ncids-css/package.json
@@ -70,8 +70,6 @@
 			"usa-date-range-picker",
 			"usa-file-input",
 			"usa-fonts",
-			"usa-file-input",
-			"usa-fonts",
 			"usa-graphic-list",
 			"usa-header",
 			"usa-hero",


### PR DESCRIPTION
Closes #926

Removed duplicate entries for usa-fonts and usa-file-input.