### PR TITLE
(#1109) Error on Patch Failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 		]
 	},
 	"scripts": {
+		"preinstall": "lerna clean --scope @nciocpl/ncids-css --y",
 		"lint": "lerna run lint",
 		"build": "lerna run build",
 		"clean:build": "lerna run clean:build",
@@ -31,7 +32,7 @@
 		"example-site:copy": "mkdirp dist/documentation-site/example-site && ncp testing/ncids-js-testing/dist dist/documentation-site/example-site",
 		"storybook:build": "lerna run build --scope=ncids-css-testing --include-dependencies",
 		"storybook:copy": "mkdirp dist/documentation-site/storybook && ncp testing/ncids-css-testing/storybook-static dist/documentation-site/storybook",
-		"postinstall": "lerna run ncids:postinstall",
+		"postinstall": "cd packages/ncids-css && yarn run ncids:postinstall",
 		"prepare": "lerna run prepare",
 		"test": "lerna run test",
 		"test:css": "lerna run test:css",

--- a/packages/ncids-css/package.json
+++ b/packages/ncids-css/package.json
@@ -25,7 +25,7 @@
 		"lint": "stylelint packages/**/*.scss",
 		"lint:fix": "stylelint scss/**/*.scss --fix",
 		"patch-uswds": "patch-package @uswds/uswds && ./scripts/sync-uswds-packages.js",
-		"ncids:postinstall": "patch-package && ./scripts/sync-uswds-packages.js",
+		"ncids:postinstall": "patch-package --error-on-fail && ./scripts/sync-uswds-packages.js",
 		"watch": "webpack --watch"
 	},
 	"author": "",


### PR DESCRIPTION
There were a few issues in play here.
1. `yarn --frozen-lockfile` does not clean out node modules.
2. The USWDS patch can only correctly be applied to a fresh copy of USWDS.
3. Our postinstall command was calling lerna, which actually stripped out the error message from patch-package saying the patch could not be applied.
4. Patch-package defaults to NOT erroring when running locally, only in CI. So at the end of the day, when you had a previous bootstrapped project and you switch a branch to one with the same package.json packages, but with an updated patch, `lerna bootstrap -- --frozen-lockfile` would SILENTLY not apply the patch and carry on as if nothing was wrong.

This commit remediates all of the above so that bad patches fail, errors are seen, and ncids-css modules is always cleared out so the patches will always be applied.

Closes #1109