### PR TITLE
(#1092) Change 'principals' to 'principles' in docs site navigation

### DIFF
--- a/docs/src/components/tmp-nav.jsx
+++ b/docs/src/components/tmp-nav.jsx
@@ -20,7 +20,7 @@ const TmpNav = () => (
 		</li>
 		<li className="nci-header-nav__primary-item">
 			<Link to="/" className="nci-header-nav__primary-link">
-				Design Principals
+				Design Principles
 			</Link>
 		</li>
 		<li className="nci-header-nav__primary-item">


### PR DESCRIPTION
Closes #1092