### PR TITLE
(#1154) Fix broken actions

### DIFF
--- a/.github/workflows/generate-bs-images.yml
+++ b/.github/workflows/generate-bs-images.yml
@@ -23,7 +23,7 @@ jobs:
           scope: '@nciocpl'
       ## Override default lerna version
       - name: Install Lerna
-        run: yarn global add lerna@6.6.2
+        run: yarn global add lerna@5.0.0
       ## Bootstrap Lerna
       - name: Bootstrap Lerna
         run: lerna bootstrap -- --frozen-lockfile

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -88,7 +88,7 @@ jobs:
           scope: '@nciocpl'
       ## Override default lerna version
       - name: Install Lerna
-        run: yarn global add lerna@6.6.2
+        run: yarn global add lerna@5.0.0
       ## Bootstrap Lerna
       - name: Bootstrap Lerna
         run: lerna bootstrap -- --frozen-lockfile


### PR DESCRIPTION
Lerna uses NX, NX points to @yarnpkg/parsers, parsers now requires Node 18. So this change is to force Lerna 5.0.0 for the bootstrap.

Closes #1154