### PR TITLE
(#1322) bugfix: error blocking js from running on component pages

### DIFF
--- a/docs/src/components/Code.jsx
+++ b/docs/src/components/Code.jsx
@@ -13,7 +13,7 @@ import ScriptWrapper from './ScriptWrapper';
 const removeNewlines = (string) => string.replace(/(\r\n|\n|\r)/gm, '');
 const wrapWithFragment = (jsx) => `<React.Fragment>${jsx}</React.Fragment>`;
 
-const htmlToJsx = (html, previewId) => {
+const htmlToJsx = (html) => {
 	// So we need a way in HTML to wireup the NCIDS-JS code when previewing HTML
 	// for those dynamic components. So we made a little component that allows
 	// us to add JS to an MDX page. The problem is that the elements are not in
@@ -22,8 +22,8 @@ const htmlToJsx = (html, previewId) => {
 	// their components.
 	const previewDisplayedEvent = `
 		(function(){
-			const target = document.getElementById('${previewId}');
-			target.dispatchEvent(new Event('NCIDS:Preview', { bubbles: true }));
+      const target =  document.getElementById(document.currentScript.parentNode.closest('.site-code-preview__showcase').id);
+      target.dispatchEvent(new Event('NCIDS:Preview', { bubbles: true }));
 		})();
 	`;
 
@@ -67,7 +67,7 @@ const getPreview = (language, code, previewId) => {
 				<>
 					<div className="site-code-preview__heading">Component Preview</div>
 					<div id={previewId} className="site-code-preview__showcase">
-						{htmlToJsx(code, previewId)}
+						{htmlToJsx(code)}
 					</div>
 				</>
 			);
@@ -134,49 +134,45 @@ const Code = ({
 			{!nopreview &&
 				(language === 'jsx' || language === 'html') &&
 				getPreview(language, code, previewId)}
-			{!noCode && (
-				<>
-					<div
-						id={'site-' + previewId}
-						className={`site-code-preview__code-wrap 
+			<div
+				id={'site-' + previewId}
+				className={`site-code-preview__code-wrap 
             ${isExpandable ? 'expandable' : ''} 
             ${isExpandable && isExpanded ? 'expanded' : ' '}
             `}>
-						<Highlight
-							{...defaultProps}
-							theme={theme}
-							code={code}
-							language={language}>
-							{({ className, style, tokens, getLineProps, getTokenProps }) => (
-								<>
-									<CopyToClipboard value={code} />
-									{/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
-									<pre className={className} style={style} tabIndex={0}>
-										{tokens.map((line, i) => (
-											<div key={i} {...getLineProps({ line, key: i })}>
-												{line.map((token, key) => (
-													<span key={key} {...getTokenProps({ token, key })} />
-												))}
-											</div>
+				<Highlight
+					{...defaultProps}
+					theme={theme}
+					code={code}
+					language={language}>
+					{({ className, style, tokens, getLineProps, getTokenProps }) => (
+						<>
+							<CopyToClipboard value={code} />
+							{/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
+							<pre className={className} style={style} tabIndex={0}>
+								{tokens.map((line, i) => (
+									<div key={i} {...getLineProps({ line, key: i })}>
+										{line.map((token, key) => (
+											<span key={key} {...getTokenProps({ token, key })} />
 										))}
-									</pre>
-								</>
-							)}
-						</Highlight>
-					</div>
-					{isExpandable && (
-						<div className="site-code-preview__show-more-toggle">
-							<button
-								aria-controls={'site-' + previewId}
-								aria-expanded={isExpanded}
-								type="button"
-								onClick={handleShowMoreToggle}
-								className="usa-button site-code-preview__show-more-toggle-btn">
-								Show {isExpanded ? 'Less' : 'More'}
-							</button>
-						</div>
+									</div>
+								))}
+							</pre>
+						</>
 					)}
-				</>
+				</Highlight>
+			</div>
+			{isExpandable && (
+				<div className="site-code-preview__show-more-toggle">
+					<button
+						aria-controls={'site-' + previewId}
+						aria-expanded={isExpanded}
+						type="button"
+						onClick={handleShowMoreToggle}
+						className="usa-button site-code-preview__show-more-toggle-btn">
+						Show {isExpanded ? 'Less' : 'More'}
+					</button>
+				</div>
 			)}
 		</div>
 	);

--- a/docs/src/components/layouts/component-page-layout.jsx
+++ b/docs/src/components/layouts/component-page-layout.jsx
@@ -129,7 +129,7 @@ const ComponentPageLayout = ({ pageContext, children }) => {
 										</ReactMarkdown>
 									)}
 									{fm.variations.code && (
-										<Code className="html" noCode="true">
+										<Code className="language-html" noCode>
 											{fm.variations.code}
 										</Code>
 									)}
@@ -155,7 +155,7 @@ const ComponentPageLayout = ({ pageContext, children }) => {
 										</ReactMarkdown>
 									)}
 									{fm.modifications.code && (
-										<Code className="html" noCode="true">
+										<Code className="language-html" noCode>
 											{fm.modifications.code}
 										</Code>
 									)}
@@ -224,8 +224,8 @@ const ComponentPageLayout = ({ pageContext, children }) => {
 											{fm.code_snippets.intro}
 										</ReactMarkdown>
 									)}
-									{fm.code_snippets.elements.map((item) => (
-										<>
+									{fm.code_snippets.elements.map((item, idx) => (
+										<React.Fragment key={idx}>
 											{item.title && <h3>{item.title}</h3>}
 											<ReactMarkdown
 												remarkPlugins={[remarkGfm]}
@@ -241,7 +241,9 @@ const ComponentPageLayout = ({ pageContext, children }) => {
 													/>
 												) : (
 													item.code && (
-														<Code className="html" nopreview={!item.preview}>
+														<Code
+															className="language-html"
+															nopreview={!item.preview}>
 															{item.code}
 														</Code>
 													)
@@ -253,7 +255,7 @@ const ComponentPageLayout = ({ pageContext, children }) => {
 												className="usa-prose">
 												{item.summary}
 											</ReactMarkdown>
-										</>
+										</React.Fragment>
 									))}
 									{fm.code_snippets.outtro && (
 										<ReactMarkdown

--- a/docs/src/scss/Code.scss
+++ b/docs/src/scss/Code.scss
@@ -7,12 +7,16 @@
 		.site-code-preview__showcase {
 			@include u-border-bottom('05');
 		}
+		.site-code-preview__code-wrap,
+		.site-code-preview__show-more-toggle {
+			display: none;
+		}
 	}
 
 	//assume that the helper function will fill in aria attributes
 
 	&__heading {
-    @include h4;
+		@include h4;
 		@include u-font('heading', 'xs');
 		@include u-padding-x(2.5);
 		@include u-padding-y(1.5);


### PR DESCRIPTION
Closes #1322

- language not being properly passed to Code component, fixed in layout
- obtain target for event dispatch by reference

The bug:
The following error appears for each instance of the Code component on the page because of a target id being wrong

<img width="706" alt="Screenshot 2023-10-19 at 2 03 47 PM" src="https://github.com/NCIOCPL/ncids/assets/45469809/2878acf1-e743-49d9-b3f1-63b87d5ff5a1">
