### PR TITLE
(#1279) Adds Icon for External Links

### DIFF
--- a/docs/src/index.scss
+++ b/docs/src/index.scss
@@ -25,6 +25,7 @@
 @forward './scss/IconCatalog.scss';
 @forward './scss/markdown-heading';
 @forward './scss/inline-code';
+@forward './scss/external-link';
 
 @forward './scss/uswds-site.scss';
 @forward './scss/component-page.scss';

--- a/docs/src/scss/_external-link.scss
+++ b/docs/src/scss/_external-link.scss
@@ -1,0 +1,20 @@
+// External Link Icon
+a[href^="http"]::after,
+a[href^="https://"]::after
+{
+	content: '';
+	width: 11px;
+	height: 11px;
+	margin-left: 4px;
+	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='currentColor' viewBox='0 0 16 16'%3E%3Cpath fill-rule='evenodd' d='M8.636 3.5a.5.5 0 0 0-.5-.5H1.5A1.5 1.5 0 0 0 0 4.5v10A1.5 1.5 0 0 0 1.5 16h10a1.5 1.5 0 0 0 1.5-1.5V7.864a.5.5 0 0 0-1 0V14.5a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h6.636a.5.5 0 0 0 .5-.5z'/%3E%3Cpath fill-rule='evenodd' d='M16 .5a.5.5 0 0 0-.5-.5h-5a.5.5 0 0 0 0 1h3.793L6.146 9.146a.5.5 0 1 0 .708.708L15 1.707V5.5a.5.5 0 0 0 1 0v-5z'/%3E%3C/svg%3E");
+	background-position: center;
+	background-repeat: no-repeat;
+	background-size: contain;
+	display: inline-block;
+}
+
+// Hide External Icon for cancer.gov
+a[href^="https://cancer.gov"]::after
+{
+	display: none !important;
+}


### PR DESCRIPTION
- Closes #1279
- Adds CSS style for links containing `http://` and `https://` which places an external link icon after the text.
- Hides external link icon for cancer.gov