### PR TITLE
(#1497) Re-wire how we do NCIDS Js init

### DIFF
--- a/docs/gatsby-browser.js
+++ b/docs/gatsby-browser.js
@@ -22,7 +22,37 @@ window.ncids = {
 	...ncidsSiteAlert,
 };
 
-// ugh
+// This registers the web component wrapper for firing the initialization
+// callback for NciDsJsInit. See https://github.com/NCIOCPL/ncids/wiki/Technical:-NCIDS-Initialization-in-Gatsby
+customElements.define(
+  "ncids-code-preview",
+  class extends HTMLElement {
+    constructor() {
+      super();
+
+			// Setup event listener such that we can remove the listener when
+			// disconnected from the DOM.
+			this.readyListener = (e) => {
+				// Only if we are still attached to the document should we fire off
+				// our event.
+				if (this.isConnected) {
+					this.dispatchEvent(new Event('NCIDS:Preview', { bubbles: true }));
+				}
+			}
+    }
+		// This fires when the component has been completely added to the real DOM.
+		connectedCallback() {
+			// Listen for when the NciDsScriptInit has been added to the page.
+			window.addEventListener('NCIDS:ShouldBeReady', this.readyListener);
+		}
+		// Remove the listener so stuff is not just hanging around.
+		disconnectedCallback() {
+			window.removeEventListener('NCIDS:ShouldBeReady', this.readyListener);
+		}
+  },
+);
+
+// This is a fake menu adapter for the Header examples.
 export class MockMegaMenuAdapter {
 	async getMegaMenuContent(id) {
 		const content = document.createElement('div');
@@ -34,3 +64,5 @@ export class MockMegaMenuAdapter {
 }
 
 window.adapter = new MockMegaMenuAdapter(true);
+
+

--- a/docs/src/components/Code.jsx
+++ b/docs/src/components/Code.jsx
@@ -8,36 +8,17 @@ import { LivePreview, LiveError, LiveProvider } from 'react-live';
 import codePreviewScope from '../code-preview-scope';
 import htmlReactParser from 'html-react-parser';
 import theme from './CodeTheme';
-import ScriptWrapper from './ScriptWrapper';
 
 const removeNewlines = (string) => string.replace(/(\r\n|\n|\r)/gm, '');
 const wrapWithFragment = (jsx) => `<React.Fragment>${jsx}</React.Fragment>`;
 
 const htmlToJsx = (html) => {
-	// So we need a way in HTML to wireup the NCIDS-JS code when previewing HTML
-	// for those dynamic components. So we made a little component that allows
-	// us to add JS to an MDX page. The problem is that the elements are not in
-	// the DOM until the page is rendered by react (in dev mode). So we are going to
-	// raise an event that will let the MDX writer when it is time to wire up
-	// their components.
-	const previewDisplayedEvent = `
-		(function(){
-			const target =  document.getElementById(document.currentScript.parentNode.closest('.site-code-preview__showcase').id);
-			target.dispatchEvent(new Event('NCIDS:Preview', { bubbles: true }));
-		})();
-	`;
-
 	try {
 		const reactElement = htmlReactParser(removeNewlines(html));
 		// The output of htmlReactParser could be a single React element
 		// or an array of React elements. reactElementToJsxString does not accept arrays
 		// so we have to wrap the output in React fragment.
-		return (
-			<>
-				{reactElement}
-				<ScriptWrapper>{`${previewDisplayedEvent}`}</ScriptWrapper>
-			</>
-		);
+		return <>{reactElement}</>;
 	} catch (error) {
 		return wrapWithFragment(html);
 	}
@@ -66,9 +47,11 @@ const getPreview = (language, code, previewId) => {
 			return (
 				<>
 					<div className="site-code-preview__heading">Component Preview</div>
-					<div id={previewId} className="site-code-preview__showcase">
+					<ncids-code-preview
+						id={previewId}
+						class="site-code-preview__showcase">
 						{htmlToJsx(code)}
-					</div>
+					</ncids-code-preview>
 				</>
 			);
 		}
@@ -136,8 +119,8 @@ const Code = ({
 				getPreview(language, code, previewId)}
 			<div
 				id={'site-' + previewId}
-				className={`site-code-preview__code-wrap 
-            ${isExpandable ? 'expandable' : ''} 
+				className={`site-code-preview__code-wrap
+            ${isExpandable ? 'expandable' : ''}
             ${isExpandable && isExpanded ? 'expanded' : ' '}
             `}>
 				<Highlight

--- a/docs/src/components/NciDsJsInit.jsx
+++ b/docs/src/components/NciDsJsInit.jsx
@@ -1,23 +1,19 @@
 import React from 'react';
 import PropType from 'prop-types';
-import { Helmet } from 'react-helmet';
+import ScriptWrapper from './ScriptWrapper';
 
-// The code below is meant to be run on Static HTML to initialize
-// ncids-js components in a <code> preview block. However, even when
-// statically published, the Gatsby app is still a React app on the
-// client side that re-hydrates the page. When a link produced by
-// gatsby-link is clicked on within the Gatsby app, it does not just
-// take the user to another page, but pre-fetches the page and replaces
-// the contents of _gatsby. Thus the window object is never cleared out.
-// So the code below tries to manage that we do not create multiple
-// listeners for the same page if a user navigates away and then back
-// to the page. It also makes sure we limit the number of event
-// listeners.
+/**
+ * Component for registering JS to be executed for each HTML preview
+ * element on an MDX page. You should only ever have 1 instance on
+ * and MDX page.
+ *
+ * @see https://github.com/NCIOCPL/ncids/wiki/Technical:-NCIDS-Initialization-in-Gatsby
+ */
 const NciDsJsInit = ({ path, children }) => {
 	const html = `
 		window.ncidsPreviewHandlers = window.ncidsPreviewHandlers || {};
 	  if (!window.ncidsPreviewHandlers['${path}']) {
-			const handler = (preview) => {
+			window.ncidsPreviewHandlers['${path}'] = (preview) => {
 				${children}
 		  }
 	  }
@@ -29,12 +25,9 @@ const NciDsJsInit = ({ path, children }) => {
 		  });
       window.ncidsPreviewListenerRegistered = true;
     }
+		window.dispatchEvent(new Event('NCIDS:ShouldBeReady', { bubbles: true }));
 	`;
-	return (
-		<Helmet>
-			<script>{html}</script>
-		</Helmet>
-	);
+	return <ScriptWrapper>{html}</ScriptWrapper>;
 };
 
 NciDsJsInit.propTypes = {

--- a/docs/src/components/ScriptWrapper.jsx
+++ b/docs/src/components/ScriptWrapper.jsx
@@ -10,6 +10,11 @@ import DangerouslySetHtmlContent from 'dangerously-set-html-content';
  * html attribute (with the <script> tag.) At first, second and third
  * glance it was the < in the <script> tag that was breaking, but
  * who knows... this seems to work.
+ *
+ * This has a big problem. The div that DangerouslySetHtmlContent
+ * uses is a ref that gets created in an useEffect. Since it is
+ * in useEffect, it does not get added to the HTML. It ends up
+ * coming in via a second rendering.
  * @param {Object} props the component props
  */
 const ScriptWrapper = ({ children }) => (

--- a/docs/src/components/layouts/component-page-layout.jsx
+++ b/docs/src/components/layouts/component-page-layout.jsx
@@ -19,6 +19,7 @@ import findObjectByKey from '../../utils/findObjectByKey';
 import TwigCode from '../TwigCode';
 import Code from '../Code';
 import MarkdownHeader from '../markdown-heading';
+import ScriptWrapper from '../ScriptWrapper';
 
 /**
  * Helper method to take site root links (e.g., /foo) and prepend the
@@ -66,6 +67,10 @@ const renderSnippetDescription = (snippetDescription) => {
 			{snippetDescription}
 		</ReactMarkdown>
 	);
+};
+
+const renderSnippetInitScript = (initScript) => {
+	return <ScriptWrapper>{initScript}</ScriptWrapper>;
 };
 
 const ComponentPageLayout = ({ pageContext, children }) => {
@@ -325,6 +330,8 @@ const ComponentPageLayout = ({ pageContext, children }) => {
 												className="usa-prose">
 												{item.intro}
 											</ReactMarkdown>
+											{item.init_script &&
+												renderSnippetInitScript(item.init_script)}
 											<>
 												{item.twig_template_path ? (
 													<TwigCode

--- a/docs/src/scss/Code.scss
+++ b/docs/src/scss/Code.scss
@@ -30,6 +30,7 @@
 		@include u-border-x('05');
 		@include u-border-y(0);
 		@include u-border('base-lightest');
+		@include u-display('block');
 	}
 
 	&__code-wrap {


### PR DESCRIPTION
So TL;DR; Gatsby v3 does not make a static HTML site. It makes some sort of Static/React mess. Add pre-fetching on top of this and we start running into issues with components that need to get added to the DOM happening randomly. This hopefully resolves some of our current issues.

See https://github.com/NCIOCPL/ncids/wiki/Technical:-NCIDS-Initialization-in-Gatsby

Closes #1497

.