### PR TITLE
(#1558) Fix post-install hook for pnpm

### DIFF
--- a/packages/ncids-css/package.json
+++ b/packages/ncids-css/package.json
@@ -25,7 +25,7 @@
 		"lint": "stylelint \"packages/**/*.scss\"",
 		"lint:fix": "stylelint \"packages/**/*.scss\" --fix",
 		"patch-uswds": "echo \"Don't use me\"",
-		"postinstall": "scripts/sync-uswds-packages.js"
+		"prepare": "scripts/sync-uswds-packages.js"
 	},
 	"author": "",
 	"license": "ISC",


### PR DESCRIPTION
Closes #1558

PR Notes:

- Fresh clone of the repo with the changes applied can build storybook, the documentation site, and example site
  - `git clone https://github.com/NCIOCPL/ncids.git ncids-testing`
  - In `ncids-testing`, ran:
    - `pnpm install`
    - In `./docs`
      - `pnpm run start`
- Was able to publish a new package and install on the platform
  - On the platform, in the container's front-end folder, ran `npm install --save @nciocpl/ncids-css@2.6.0-alpha.3 @ncipcpl/ncids-js@2.6.0-alpha.3`