### PR TITLE
(#1682) increase docs page comment contrast ratio

### DIFF
--- a/docs/src/components/CodeTheme.js
+++ b/docs/src/components/CodeTheme.js
@@ -8,7 +8,7 @@ const theme = {
 		{
 			types: ['comment', 'prolog', 'doctype', 'cdata'],
 			style: {
-				color: '#999988',
+				color: '#71767a', //gray-cool-50
 				fontStyle: 'italic',
 			},
 		},


### PR DESCRIPTION
Closes #1682

- increased doc page code comment contrast ratio to 4.59 from 2.88 to meet WCAG 2.0 AA minimum contrast ratio