### PR TITLE
(#1850) Bump Github Action Versions

### DIFF
--- a/.github/workflows/generate-bs-images.yml
+++ b/.github/workflows/generate-bs-images.yml
@@ -12,13 +12,13 @@ jobs:
     steps:
       ## This clones and checks out.
       - name: Checkout branch
-        uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v2
+        uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
         with:
           version: 9
       ## Setup node and npm caching.
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
@@ -44,8 +44,9 @@ jobs:
         env:
           CI: true
           BACKSTOP_BASE_URL: http://localhost:8080/
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         name: Upload reference images
         with:
           name: backstopjs-reference
           path: /home/runner/work/ncids/ncids/testing/ncids-css-testing/.backstop/reference
+          include-hidden-files: true

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -78,13 +78,13 @@ jobs:
             })
       ## This clones and checks out.
       - name: Checkout branch
-        uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v2
+        uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
         with:
           version: 9
       ## Setup node and npm caching.
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
@@ -168,18 +168,20 @@ jobs:
           CI: true
           BACKSTOP_BASE_URL: ${{ format('http://localhost:8080/{0}/storybook/', steps.set_vars.outputs.build_name) }}
       ## Upload failed css tests
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         name: Upload failed tests
         if: failure()
         with:
           name: failed-backstopjs
           path: /home/runner/work/ncids/ncids/testing/ncids-css-testing/.backstop/
+          include-hidden-files: true
       ## Upload successful css tests
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         name: Upload successful tests
         with:
           name: success-backstopjs
           path: /home/runner/work/ncids/ncids/testing/ncids-css-testing/.backstop/test/**/report.json
+          include-hidden-files: true
       ## TODO: Upload the test results artifact
       #      - name: Archive production artifacts
       #        uses: actions/upload-artifact@v1
@@ -188,10 +190,11 @@ jobs:
       #          path: coverage
       ## Upload the test results artifact
       - name: Archive production artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: documentation-site
           path: dist/documentation-site/
+          include-hidden-files: true
   deploy-doc-site:
     name: Deploy documentation site to dev server
     ## Only do this if the repo is NCIOCPL
@@ -201,7 +204,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download built site
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: documentation-site
           path: documentation-site


### PR DESCRIPTION
- Bumped upload-artifact, download-artifact and checkout as those versions are being retired.
- Bumped setup-node while we were at it.

Closes #1850
